### PR TITLE
Twitter Bootstrap Plugin and fields Plugin version is old.

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -31,8 +31,8 @@ grails.project.dependency.resolution = {
         compile ":jquery:1.7.1"
         compile ":resources:1.1.6"
 
-		runtime ":twitter-bootstrap:2.0.0.16"
-		runtime ":fields:1.0.1"
+		runtime ":twitter-bootstrap:2.0.2.25"
+		runtime ":fields:1.1"
 		runtime ":cache-headers:1.1.5"
 		runtime ":cached-resources:1.0"
 		runtime ":zipped-resources:1.0"

--- a/readme.md
+++ b/readme.md
@@ -10,8 +10,8 @@ This is an experimental Grails project using Twitter Bootstrap for scaffolded vi
 
 You can either use this project as a template or to add to an existing Grails application:
 
-1. Install the _Twitter Bootstrap Resources_ plugin, i.e. add `runtime ":twitter-bootstrap:2.0.0.16"` to _BuildConfig.groovy_.
-2. Install the _Fields_ plugin, i.e. add `runtime ":fields:1.0.1"` to _BuildConfig.groovy_.
+1. Install the _Twitter Bootstrap Resources_ plugin, i.e. add `runtime ":twitter-bootstrap:2.0.2.25"` to _BuildConfig.groovy_.
+2. Install the _Fields_ plugin, i.e. add `runtime ":fields:1.1"` to _BuildConfig.groovy_.
 3. Copy the following files into your Grails application.
    * `src/templates/scaffolding/*` 
    * `web-app/css/scaffolding.css`

--- a/web-app/css/scaffolding.css
+++ b/web-app/css/scaffolding.css
@@ -60,7 +60,7 @@ table th.desc a:after {
 	height: 14px;
 	margin-left: 0.3em;
 	vertical-align: text-top;
-	background-image: url(../plugins/twitter-bootstrap-2.0.0.16/img/glyphicons-halflings.png);
+	background-image: url(../plugins/twitter-bootstrap-2.0.2.25/img/glyphicons-halflings.png);
 	background-position: 14px 14px;
 	background-repeat: no-repeat;
 }


### PR DESCRIPTION
Please update two plugin version.
- Twitter Bootstrap Plugin 2.0.0.16 -> 2.0.2.25
- fields Plugin 1.0.1 -> 1.1
