### PR TITLE
Updated twitter-bootstrap (2.1.0.1) and fields (1.3)

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -31,13 +31,13 @@ grails.project.dependency.resolution = {
         compile ":jquery:1.7.1"
         compile ":resources:1.1.6"
 
-		runtime ":twitter-bootstrap:2.0.2.25"
-		runtime ":fields:1.1"
+		runtime ":twitter-bootstrap:2.1.0.1"
+		runtime ":fields:1.3"
 		runtime ":cache-headers:1.1.5"
 		runtime ":cached-resources:1.0"
 		runtime ":zipped-resources:1.0"
 
-		build ":cloud-foundry:1.2.1"
+		//build ":cloud-foundry:1.2.1"
         build ":tomcat:$grailsVersion"
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -10,8 +10,8 @@ This is an experimental Grails project using Twitter Bootstrap for scaffolded vi
 
 You can either use this project as a template or to add to an existing Grails application:
 
-1. Install the _Twitter Bootstrap Resources_ plugin, i.e. add `runtime ":twitter-bootstrap:2.0.2.25"` to _BuildConfig.groovy_.
-2. Install the _Fields_ plugin, i.e. add `runtime ":fields:1.1"` to _BuildConfig.groovy_.
+1. Install the _Twitter Bootstrap Resources_ plugin, i.e. add `runtime ":twitter-bootstrap:2.1.0.1"` to _BuildConfig.groovy_.
+2. Install the _Fields_ plugin, i.e. add `runtime ":fields:1.3"` to _BuildConfig.groovy_.
 3. Copy the following files into your Grails application.
    * `src/templates/scaffolding/*` 
    * `web-app/css/scaffolding.css`


### PR DESCRIPTION
New version of twitter bootstrap. 
The navigation bar is now in bright theme (it is default), to bring back dark theme use `.navbar-inverse` class.
